### PR TITLE
Saga cleanup

### DIFF
--- a/src/BookKeeping/Msape.BookKeeping.Api/Controllers/TransactionsController.cs
+++ b/src/BookKeeping/Msape.BookKeeping.Api/Controllers/TransactionsController.cs
@@ -5,6 +5,7 @@ using Msape.BookKeeping.Data;
 using Msape.BookKeeping.Data.EF;
 using Msape.BookKeeping.InternalContracts;
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Msape.BookKeeping.Api.Controllers
@@ -111,14 +112,16 @@ namespace Msape.BookKeeping.Api.Controllers
                 DestAccount = toSubject.ToAccountId(),
                 SourceAccount = fromSubject.ToAccountId(),
                 Currency = 0,
-                Charge = new Charge()
-                {
-                    Id = chargeId,
-                    Amount = 30,
-                    Currency = 0,
-                    TransactionType = TransactionType.TransactionCharge,
-                    PayToAccount = chargeSubject.ToAccountId()
-                }
+                Charges = ListOf(
+                    new Charge()
+                    {
+                        Id = chargeId,
+                        Amount = 30,
+                        Currency = 0,
+                        TransactionType = TransactionType.TransactionCharge,
+                        PayToAccount = chargeSubject.ToAccountId()
+                    }
+                    )
             },
             HttpContext.RequestAborted
             ).ConfigureAwait(false);
@@ -146,14 +149,16 @@ namespace Msape.BookKeeping.Api.Controllers
                 TransactionType = TransactionType.CustomerWithdrawal,
                 DestAccount = agentSubject.ToAccountId(),
                 SourceAccount = customerSubject.ToAccountId(),
-                Charge = new Charge()
-                {
-                    Id = chargeId,
-                    Amount = Math.Ceiling(model.Amount * 0.01M),
-                    Currency = 0,
-                    TransactionType = TransactionType.TransactionCharge,
-                    PayToAccount = chargeSubject.ToAccountId()
-                },
+                Charges = ListOf(
+                    new Charge()
+                    {
+                        Id = chargeId,
+                        Amount = Math.Ceiling(model.Amount * 0.01M),
+                        Currency = 0,
+                        TransactionType = TransactionType.TransactionCharge,
+                        PayToAccount = chargeSubject.ToAccountId()
+                    }
+                    ),
                 Currency = 0
             },
             HttpContext.RequestAborted
@@ -181,7 +186,7 @@ namespace Msape.BookKeeping.Api.Controllers
                 DestAccount = billSubject.ToAccountId(),
                 SourceAccount = customerSubject.ToAccountId(),
                 ExternalReference = model.AccountNumber,
-                Charge = null,
+                Charges = null,
                 Currency = 0
             },
             HttpContext.RequestAborted
@@ -208,7 +213,7 @@ namespace Msape.BookKeeping.Api.Controllers
                 TransactionType = TransactionType.PaymentToTill,
                 DestAccount = tillSubject.ToAccountId(),
                 SourceAccount = customerSubject.ToAccountId(),
-                Charge = null,
+                Charges = null,
                 Currency = 0
             },
             HttpContext.RequestAborted
@@ -247,5 +252,9 @@ namespace Msape.BookKeeping.Api.Controllers
         [NonAction]
         private async Task<CacheableAccountSubject> GetSubjectAsync(string accountNumber, AccountType accountType)
             => await _subjectCache.GetSubjectAsync(accountNumber, accountType, HttpContext.RequestAborted).ConfigureAwait(false);
+
+        [NonAction]
+        private List<T> ListOf<T>(params T[] values)
+            => values == null ? new List<T>() : new List<T>(values);
     }
 }

--- a/src/BookKeeping/Msape.BookKeeping.Components.Tests/Posting/PostTransactionChargeConsumer_Specs.cs
+++ b/src/BookKeeping/Msape.BookKeeping.Components.Tests/Posting/PostTransactionChargeConsumer_Specs.cs
@@ -2,6 +2,7 @@
 using Msape.BookKeeping.Components.Consumers.Posting;
 using Msape.BookKeeping.Data.EF;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
@@ -66,18 +67,21 @@ namespace Msape.BookKeeping.Components.Tests.Posting
                         src,
                         dest,
                         "notes",
-                        new Data.Transaction
-                        (
-                            chargeId,
-                            new Data.Money(0, 10),
-                            Data.TransactionType.TransactionCharge,
-                            false,
-                            DateTime.UtcNow,
-                            src,
-                            chrg,
-                            "null",
-                            null
-                        )
+                        new List<Data.Transaction>()
+                        {
+                            new Data.Transaction
+                            (
+                                chargeId,
+                                new Data.Money(0, 10),
+                                Data.TransactionType.TransactionCharge,
+                                false,
+                                DateTime.UtcNow,
+                                src,
+                                chrg,
+                                "null",
+                                null
+                            )
+                        }
                         )
                     );
             tx.Entity.PostToSource(cust.Entity);

--- a/src/BookKeeping/Msape.BookKeeping.Components.Tests/Posting/PostTransactionToSourceConsumer_Specs.cs
+++ b/src/BookKeeping/Msape.BookKeeping.Components.Tests/Posting/PostTransactionToSourceConsumer_Specs.cs
@@ -49,7 +49,7 @@ namespace Msape.BookKeeping.Components.Tests.Posting
                 IsContra = false,
                 Currency = 0,
                 TransactionType = Data.TransactionType.AgentFloatTopup,
-                Charge = null,
+                Charges = null,
                 SourceAccount = new AccountId()
                 {
                     Id = 1,
@@ -132,7 +132,7 @@ namespace Msape.BookKeeping.Components.Tests.Posting
                 IsContra = false,
                 Currency = 0,
                 TransactionType = Data.TransactionType.AgentFloatTopup,
-                Charge = null,
+                Charges = null,
                 SourceAccount = new AccountId()
                 {
                     Id = 1,
@@ -215,7 +215,7 @@ namespace Msape.BookKeeping.Components.Tests.Posting
                 IsContra = false,
                 Currency = 0,
                 TransactionType = Data.TransactionType.AgentFloatTopup,
-                Charge = null,
+                Charges = null,
                 SourceAccount = new AccountId()
                 {
                     Id = 1,

--- a/src/BookKeeping/Msape.BookKeeping.Components.Tests/Posting/PostingSaga_Specs.cs
+++ b/src/BookKeeping/Msape.BookKeeping.Components.Tests/Posting/PostingSaga_Specs.cs
@@ -62,7 +62,7 @@ namespace Msape.BookKeeping.Components.Tests.Posting
                 Timestamp = DateTime.UtcNow,
                 TransactionType = Data.TransactionType.CustomerSendMoney,
                 SourceBalanceAfter = new MoneyInfo() { Currency = 1, Value = 50_000 },
-                ChargeInfo = null
+                Charges = null
             };
             await SendToSaga(message);
             Assert.True(await _sagaHarness.Sagas.Any());
@@ -106,7 +106,7 @@ namespace Msape.BookKeeping.Components.Tests.Posting
                 Timestamp = DateTime.UtcNow,
                 TransactionType = Data.TransactionType.CustomerSendMoney,
                 SourceBalanceAfter = new MoneyInfo() { Currency = 1, Value = 50_000 },
-                ChargeInfo = null
+                Charges = null
             };
             await SendToSaga(message);
             Assert.True(await _sagaHarness.Sagas.Any());

--- a/src/BookKeeping/Msape.BookKeeping.Components.Tests/Posting/PostingSaga_Specs.cs
+++ b/src/BookKeeping/Msape.BookKeeping.Components.Tests/Posting/PostingSaga_Specs.cs
@@ -22,7 +22,8 @@ namespace Msape.BookKeeping.Components.Tests.Posting
             base.ConfigureServices(services);
             services.AddSingleton(provider => new PostTransactionStateMachineOptions()
             {
-                AccountTypeSendEndpoint = (type) => _testHarness.InputQueueAddress
+                AccountTypeSendEndpoint = (type) => _testHarness.InputQueueAddress,
+                TtlProvider = (type) => -1
             });
         }
     }

--- a/src/BookKeeping/Msape.BookKeeping.Components.Tests/Posting/PostingSaga_Specs.cs
+++ b/src/BookKeeping/Msape.BookKeeping.Components.Tests/Posting/PostingSaga_Specs.cs
@@ -22,8 +22,7 @@ namespace Msape.BookKeeping.Components.Tests.Posting
             base.ConfigureServices(services);
             services.AddSingleton(provider => new PostTransactionStateMachineOptions()
             {
-                AccountTypeSendEndpoint = (type) => _testHarness.InputQueueAddress,
-                TransactionProcessingSendEndpoint = _testHarness.InputQueueAddress
+                AccountTypeSendEndpoint = (type) => _testHarness.InputQueueAddress
             });
         }
     }

--- a/src/BookKeeping/Msape.BookKeeping.Components/Consumers/Posting/Messages/TransactionPostedToSource.cs
+++ b/src/BookKeeping/Msape.BookKeeping.Components/Consumers/Posting/Messages/TransactionPostedToSource.cs
@@ -1,6 +1,7 @@
 ﻿using Msape.BookKeeping.Data;
 using Msape.BookKeeping.InternalContracts;
 using System;
+using System.Collections.Generic;
 
 namespace Msape.BookKeeping.Components.Consumers.Posting
 {
@@ -15,6 +16,6 @@ namespace Msape.BookKeeping.Components.Consumers.Posting
         public AccountId SourceAccount { get; init; }
         public AccountId DestAccount { get; init; }
         public MoneyInfo SourceBalanceAfter { get; init; }
-        public LinkedTransactionInfo ChargeInfo { get; init; }
+        public List<LinkedTransactionInfo> Charges { get; init; } = new List<LinkedTransactionInfo>();
     }
 }

--- a/src/BookKeeping/Msape.BookKeeping.Components/Consumers/Posting/Saga/PostTransactionSaga.cs
+++ b/src/BookKeeping/Msape.BookKeeping.Components/Consumers/Posting/Saga/PostTransactionSaga.cs
@@ -14,7 +14,7 @@ namespace Msape.BookKeeping.Components.Consumers.Posting.Saga
         [JsonProperty("_etag")]
         public string Etag { get; set; }
         [JsonProperty("_ttl")]
-        public string Ttl { get; set; }
+        public long Ttl { get; set; }
         public string Type { get; private set; } = "Sagas/Transactions";
         public string InstanceState { get; set; }
         //init data

--- a/src/BookKeeping/Msape.BookKeeping.Components/Consumers/Posting/Saga/PostTransactionSaga.cs
+++ b/src/BookKeeping/Msape.BookKeeping.Components/Consumers/Posting/Saga/PostTransactionSaga.cs
@@ -2,6 +2,7 @@
 using Msape.BookKeeping.Data;
 using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
 
 namespace Msape.BookKeeping.Components.Consumers.Posting.Saga
 {
@@ -27,8 +28,8 @@ namespace Msape.BookKeeping.Components.Consumers.Posting.Saga
         //data for entries
         public SagaEntryData PostToDestData { get; set; }
         public SagaEntryData PostToSourceData { get; set; }
-        public SagaInstanceChargeInfo ChargeInfo { get; set; }
-        public SagaEntryData PostToChargeData { get; set; }
-        public SagaEntryData UndoPostToSourceData { get; set; }
+        public SagaEntryData CancelTxData { get; set; }
+        public List<SagaInstanceChargeInfo> Charges { get; set; } = new List<SagaInstanceChargeInfo>();
+        public List<ChargeSagaEntryData> ChargeEntries { get; set; } = new List<ChargeSagaEntryData>();
     }
 }

--- a/src/BookKeeping/Msape.BookKeeping.Components/Consumers/Posting/Saga/PostTransactionStateMachine.cs
+++ b/src/BookKeeping/Msape.BookKeeping.Components/Consumers/Posting/Saga/PostTransactionStateMachine.cs
@@ -54,7 +54,7 @@ namespace Msape.BookKeeping.Components.Consumers.Posting.Saga
 
             Initially(
                 When(PostedToSource)
-                    .CopyData()
+                    .CopyData(sagaOptions)
                     .TransitionTo(PostingToDestAccount)
                     .SendPostDest(sagaOptions)
                     );

--- a/src/BookKeeping/Msape.BookKeeping.Components/Consumers/Posting/Saga/PostTransactionStateMachineOptions.cs
+++ b/src/BookKeeping/Msape.BookKeeping.Components/Consumers/Posting/Saga/PostTransactionStateMachineOptions.cs
@@ -6,5 +6,7 @@ namespace Msape.BookKeeping.Components.Consumers.Posting.Saga
     public class PostTransactionStateMachineOptions
     {
         public Func<AccountType, Uri> AccountTypeSendEndpoint { get; set; }
+
+        public Func<TransactionType, long> TtlProvider { get; set; }
     }
 }

--- a/src/BookKeeping/Msape.BookKeeping.Components/Consumers/Posting/Saga/PostTransactionStateMachineOptions.cs
+++ b/src/BookKeeping/Msape.BookKeeping.Components/Consumers/Posting/Saga/PostTransactionStateMachineOptions.cs
@@ -5,8 +5,6 @@ namespace Msape.BookKeeping.Components.Consumers.Posting.Saga
 {
     public class PostTransactionStateMachineOptions
     {
-        public Uri TransactionProcessingSendEndpoint { get; init; }
-
         public Func<AccountType, Uri> AccountTypeSendEndpoint { get; set; }
     }
 }

--- a/src/BookKeeping/Msape.BookKeeping.Components/Consumers/Posting/Saga/SagaEntryData.cs
+++ b/src/BookKeeping/Msape.BookKeeping.Components/Consumers/Posting/Saga/SagaEntryData.cs
@@ -9,4 +9,11 @@ namespace Msape.BookKeeping.Components.Consumers.Posting.Saga
         public DateTime Timestamp { get; set; }
         public DebitOrCreditFailReason? FailReason { get; set; }
     }
+
+    public class ChargeSagaEntryData
+    {
+        public MoneyInfo BalanceAfter { get; set; }
+        public DateTime Timestamp { get; set; }
+        public long ChargeId { get; set; }
+    }
 }

--- a/src/BookKeeping/Msape.BookKeeping.Components/Consumers/Posting/Saga/SagaInstanceChargeInfo.cs
+++ b/src/BookKeeping/Msape.BookKeeping.Components/Consumers/Posting/Saga/SagaInstanceChargeInfo.cs
@@ -9,13 +9,13 @@ namespace Msape.BookKeeping.Components.Consumers.Posting.Saga
         public TransactionType TransactionType { get; set; }
         public SagaAccountInfo DestAccount { get; set; }
 
-        public static SagaInstanceChargeInfo From(TransactionPostedToSource @event, PostTransactionSaga saga)
-            => @event.ChargeInfo == null ? null : new SagaInstanceChargeInfo()
+        public static SagaInstanceChargeInfo From(LinkedTransactionInfo charge)
+            => charge == null ? null : new SagaInstanceChargeInfo()
             {
-                ChargeId = @event.ChargeInfo.TransactionId,
-                Amount = @event.ChargeInfo.Amount,
-                TransactionType = @event.ChargeInfo.TransactionType,
-                DestAccount = SagaAccountInfo.FromAccountId(@event.ChargeInfo.DestAccount)
+                ChargeId = charge.TransactionId,
+                Amount = charge.Amount,
+                TransactionType = charge.TransactionType,
+                DestAccount = SagaAccountInfo.FromAccountId(charge.DestAccount)
             };
     }
 }

--- a/src/BookKeeping/Msape.BookKeeping.Components/Consumers/Posting/Saga/TransactionStateMachineExtensions.cs
+++ b/src/BookKeeping/Msape.BookKeeping.Components/Consumers/Posting/Saga/TransactionStateMachineExtensions.cs
@@ -47,7 +47,7 @@ namespace Msape.BookKeeping.Components.Consumers.Posting.Saga
                     }
                 );
         }
-        public static EventActivityBinder<PostTransactionSaga, PostTransactionToDestFailed> SendUndoInitiate(this EventActivityBinder<PostTransactionSaga, PostTransactionToDestFailed> binder, PostTransactionStateMachineOptions sagaOptions)
+        public static EventActivityBinder<PostTransactionSaga, PostTransactionToDestFailed> SendCancel(this EventActivityBinder<PostTransactionSaga, PostTransactionToDestFailed> binder, PostTransactionStateMachineOptions sagaOptions)
         {
             return
                 binder.Send(
@@ -57,22 +57,6 @@ namespace Msape.BookKeeping.Components.Consumers.Posting.Saga
                         PostingId = context.Instance.CorrelationId,
                         TransactionId = context.Data.TransactionId,
                         Timestamp = context.Instance.Timestamp
-                    },
-                    contextCallback: context => context.ResponseAddress ??= context.SourceAddress
-                );
-        }
-
-        public static EventActivityBinder<PostTransactionSaga, TransactionCancelled> SendFailTransaction(this EventActivityBinder<PostTransactionSaga, TransactionCancelled> binder, PostTransactionStateMachineOptions sagaOptions)
-        {
-            return
-                binder.Send(
-                    destinationAddress: sagaOptions.TransactionProcessingSendEndpoint,
-                    messageFactory: context => new FailTransaction()
-                    {
-                        PostingId = context.Instance.CorrelationId,
-                        TransactionId = context.Instance.TransactionId,
-                        Timestamp = context.Instance.Timestamp,
-                        FailReason = context.Instance.PostToDestData.FailReason.GetValueOrDefault()
                     },
                     contextCallback: context => context.ResponseAddress ??= context.SourceAddress
                 );

--- a/src/BookKeeping/Msape.BookKeeping.Components/Consumers/Posting/Saga/TransactionStateMachineExtensions.cs
+++ b/src/BookKeeping/Msape.BookKeeping.Components/Consumers/Posting/Saga/TransactionStateMachineExtensions.cs
@@ -12,7 +12,7 @@ namespace Msape.BookKeeping.Components.Consumers.Posting.Saga
 {
     public static class TransactionStateMachineExtensions
     {
-        public static EventActivityBinder<PostTransactionSaga, TransactionPostedToSource> CopyData(this EventActivityBinder<PostTransactionSaga, TransactionPostedToSource> binder)
+        public static EventActivityBinder<PostTransactionSaga, TransactionPostedToSource> CopyData(this EventActivityBinder<PostTransactionSaga, TransactionPostedToSource> binder, PostTransactionStateMachineOptions sagaOptions)
         {
             return binder
                 .Then(context =>
@@ -31,6 +31,7 @@ namespace Msape.BookKeeping.Components.Consumers.Posting.Saga
                         Timestamp = context.Data.Timestamp
                     };
                     context.Instance.Charges.Add(SagaInstanceChargeInfo.From(context.Data, context.Instance));
+                    context.Instance.Ttl = sagaOptions.TtlProvider(context.Data.TransactionType);
                 });
         }
         public static EventActivityBinder<PostTransactionSaga, TransactionPostedToSource> SendPostDest(this EventActivityBinder<PostTransactionSaga, TransactionPostedToSource> binder, PostTransactionStateMachineOptions sagaOptions)

--- a/src/BookKeeping/Msape.BookKeeping.Components/Consumers/Posting/Saga/TransactionStateMachineExtensions.cs
+++ b/src/BookKeeping/Msape.BookKeeping.Components/Consumers/Posting/Saga/TransactionStateMachineExtensions.cs
@@ -30,7 +30,10 @@ namespace Msape.BookKeeping.Components.Consumers.Posting.Saga
                         BalanceAfter = context.Data.SourceBalanceAfter,
                         Timestamp = context.Data.Timestamp
                     };
-                    context.Instance.Charges.Add(SagaInstanceChargeInfo.From(context.Data, context.Instance));
+                    if(context.Data.Charges != null)
+                    {
+                        context.Instance.Charges = context.Data.Charges.ConvertAll(c => SagaInstanceChargeInfo.From(c));
+                    }
                     context.Instance.Ttl = sagaOptions.TtlProvider(context.Data.TransactionType);
                 });
         }

--- a/src/BookKeeping/Msape.BookKeeping.Data/Transaction.cs
+++ b/src/BookKeeping/Msape.BookKeeping.Data/Transaction.cs
@@ -32,7 +32,7 @@ namespace Msape.BookKeeping.Data
             TransactionAccountInfo sourceAccount,
             TransactionAccountInfo destAccount,
             string notes,
-            Transaction charge)
+            List<Transaction> charges)
         {
 
             if (sourceAccount is null)
@@ -58,14 +58,17 @@ namespace Msape.BookKeeping.Data
             DestAccount = destAccount;
             Notes = notes;
             FailReason = TransactionFailReason.None;
-            if (charge != null)
+            if (charges != null)
             {
-                if(charge.ParentId.HasValue && charge.ParentId.Value != Id)
+                foreach (var charge in charges)
                 {
-                    throw new ArgumentException($"Charge.ParentId ({charge.ParentId}) value is different from transaction.Id ({Id})");
+                    if (charge.ParentId.HasValue && charge.ParentId.Value != Id)
+                    {
+                        throw new ArgumentException($"Charge.ParentId ({charge.ParentId}) value is different from transaction.Id ({Id})");
+                    }
+                    charge.ParentId = Id;
+                    Charges.Add(charge);
                 }
-                charge.ParentId = Id;
-                Charges.Add(charge);
             }
         }
 

--- a/src/BookKeeping/Msape.BookKeeping.InternalContracts/PostTransaction.cs
+++ b/src/BookKeeping/Msape.BookKeeping.InternalContracts/PostTransaction.cs
@@ -1,5 +1,6 @@
 ﻿using Msape.BookKeeping.Data;
 using System;
+using System.Collections.Generic;
 
 namespace Msape.BookKeeping.InternalContracts
 {
@@ -15,7 +16,7 @@ namespace Msape.BookKeeping.InternalContracts
         public decimal Amount { get; init; }
         public int Currency { get; init; }
         public DateTime Timestamp { get; init; }
-        public Charge Charge { get; init; }
+        public List<Charge> Charges { get; init; } = new List<Charge>();
 
     }
 }

--- a/src/BookKeeping/Msape.BookKeeping.Service/Program.cs
+++ b/src/BookKeeping/Msape.BookKeeping.Service/Program.cs
@@ -36,7 +36,6 @@ namespace Msape.BookKeeping.Service
 
                     var opts = new PostTransactionStateMachineOptions()
                     {
-                        TransactionProcessingSendEndpoint = new Uri("queue:transaction-processing"),
                         AccountTypeSendEndpoint = new Func<AccountType, Uri>(accountType =>
                         {
                             var name = AccountTypeQueueHelper.GetQueueName(accountType);

--- a/src/BookKeeping/Msape.BookKeeping.Service/Program.cs
+++ b/src/BookKeeping/Msape.BookKeeping.Service/Program.cs
@@ -40,10 +40,10 @@ namespace Msape.BookKeeping.Service
                         {
                             var name = AccountTypeQueueHelper.GetQueueName(accountType);
                             return new Uri($"queue:{name}");
-                        })
+                        }),
+                        TtlProvider = (txType) => -1L
                     };
                     services.AddSingleton(client);
-                    //services.AddSingleton<ICosmosAccount>(new CosmosAccount(client, ("msape2", "accounts"), ("msape2", "account_numbers"), ("msape2", "transactions")));
                     services.AddSingleton(opts);
 
                     services.AddMassTransit(configurator =>


### PR DESCRIPTION
- Removed unnecessary states (`MarkingAsFailed`) from the state machine
- Removed `TransactionFailed` event from state machine
- Support for posting multiple charges per workflow on the state machine
- Saga instance has support for dynamically provided ttl. This can be used with Cosmos DB for saga store cleanup